### PR TITLE
fix(virtio): fix mmap region to map only shared memory

### DIFF
--- a/src/virtio/src/device.rs
+++ b/src/virtio/src/device.rs
@@ -194,7 +194,7 @@ impl VirtioDeviceCommon {
         // Create a mmap region with proper permissions.
         let mmap_region = match MmapRegion::build(
             Some(FileOffset::new(file, mmap_offset)),
-            base_addr as usize + size as usize,
+            size as usize,
             PROT_READ | PROT_WRITE,
             MAP_SHARED,
         ) {


### PR DESCRIPTION
Previously, the VirtioDeviceCommon mmap implementation passed `base_addr + size` to MmapRegion::build, which caused the mapped user-space region to extend beyond the actual shared memory region. This led to incorrect memory mapping: the kernel remapped `shmem_addr + size` bytes instead of just the shared memory itself.

This commit changes the mapping call to pass only `size` as the length, so that the user-space virtual address region maps exactly the shared memory buffer as defined in the device tree.

Fixes potential buffer overflows and ensures the user process sees the correct memory region.