### PR TITLE
fix: remove hardcoded Cargo linker config and document cross-build setup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,0 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-
-[target.riscv64gc-unknown-linux-gnu]
-linker = "riscv64-linux-gnu-gcc"
-
-[target.arm-unknown-linux-gnueabi]
-linker = "arm-linux-gnueabi-gcc"

--- a/README.md
+++ b/README.md
@@ -9,18 +9,90 @@ Vhost-user backend devices.
 
 ## Getting Started
 
-To begin utilizing VirtIO device support in Bao Hypervisor, follow these steps:
+This project can be built either standalone (using a system cross-toolchain) or as part of Buildroot.
+The build system does not rely on a hardcoded `.cargo/config.toml`. Instead, the linker is selected via
+environment variables, which allows full integration with external build systems such as Buildroot.
 
-1. Clone this repository to your local environment.
+To begin utilizing VirtIO device support in Bao Hypervisor, follow these steps
 
+### Prerequisites
+
+- Rust (stable)
+- `cargo`
+- The appropriate Rust target installed via `rustup`
+- A cross-compiler for the desired target architecture
+
+### Install Rust Targets
+
+Install the Rust targets corresponding to the architectures you want to build for:
+```bash
+rustup target add aarch64-unknown-linux-gnu
+rustup target add riscv64gc-unknown-linux-gnu
+rustup target add arm-unknown-linux-gnueabi
 ```
-git clone git@github.com:joaopeixoto13/bao-virtio-dm.git
+
+### Install Cross Toolchains
+
+Install the appropriate cross-compilers for your host system.
+```bash
+sudo apt install \
+  gcc-aarch64-linux-gnu \
+  gcc-riscv64-linux-gnu \
+  gcc-arm-linux-gnueabi
 ```
 
-2. Build the source code (e.g. Aarch64):
+### Export the Linker for Cargo
 
+Cargo requires an explicit linker when cross-compiling.
+Set the linker using the `CARGO_TARGET_<TRIPLE>_LINKER` environment variable.
+
+1. AArch64 (Linux GNU)
+```bash
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 ```
+
+RISC-V 64 (Linux GNU)
+```bash
+export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
+```
+
+ARM 32-bit (Linux GNU EABI)
+```bash
+export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc
+```
+
+### Clone and Build
+
+Clone the repository:
+```bash
+git clone git@github.com:bao-project/bao-virtio-dm.git
+cd bao-virtio-dm
+```
+
+1. Build for AArch64 (64-bit ARM)
+```bash
 cargo build --target=aarch64-unknown-linux-gnu --release
+```
+Output binary:
+```bash
+target/aarch64-unknown-linux-gnu/release/bao-virtio-dm
+
+2. Build for RISC-V 64-bit
+```bash
+cargo build --target=riscv64gc-unknown-linux-gnu --release
+```
+Output binary:
+```bash
+target/riscv64gc-unknown-linux-gnu/release/bao-virtio-dm
+```
+
+3. Build for ARM 32-bit (EABI)
+```bash
+cargo build --target=arm-unknown-linux-gnueabi --release
+```
+Output binary:
+```bash
+target/arm-unknown-linux-gnueabi/release/bao-virtio-dm
 ```
 
 ## Supported Devices

--- a/src/virtio/src/block/virtio/inorder_handler.rs
+++ b/src/virtio/src/block/virtio/inorder_handler.rs
@@ -72,6 +72,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum Error {
     GuestMemory(vm_memory::GuestMemoryError),

--- a/src/virtio/src/console/virtio/console_handler.rs
+++ b/src/virtio/src/console/virtio/console_handler.rs
@@ -112,6 +112,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum Error {
     GuestMemory(vm_memory::GuestMemoryError),

--- a/src/virtio/src/net/virtio/simple_handler.rs
+++ b/src/virtio/src/net/virtio/simple_handler.rs
@@ -26,6 +26,7 @@ const MAX_BUFFER_SIZE: usize = 65562;
 const RXQ_INDEX: u16 = 0;
 const TXQ_INDEX: u16 = 1;
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum Error {
     GuestMemory(vm_memory::GuestMemoryError),


### PR DESCRIPTION
Drop `.cargo/config.toml` with fixed linkers and update README to describe cross-compilation using external toolchains selected via environment variables, enabling standalone builds and proper Buildroot integration.